### PR TITLE
Better multicast support + OpenBSD fix

### DIFF
--- a/pydiglib/main.py
+++ b/pydiglib/main.py
@@ -86,7 +86,10 @@ def main(args):
         if not response.tc:
             print(";; UDP response from %s, %d bytes, in %.3f sec" %
                   (responder_addr, size_response, (t2-t1)))
-            if server_addr != "0.0.0.0" and responder_addr[0] != server_addr:
+            is_ipv4_multicast = 224 <= int(server_addr.split('.')[0]) <= 239
+            if server_addr != "0.0.0.0" and \
+               responder_addr[0] != server_addr and
+               not is_ipv4_multicast:
                 print("WARNING: Response from unexpected address %s" %
                       responder_addr[0])
 

--- a/pydiglib/query.py
+++ b/pydiglib/query.py
@@ -142,6 +142,8 @@ def send_request_udp(pkt, host, port, family, itimeout, retries):
     s = socket.socket(family, socket.SOCK_DGRAM)
     if options["srcip"]:
         s.bind((options["srcip"], 0))
+        s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, \
+            socket.inet_aton(options["srcip"]))
     timeout = itimeout
     while (retries > 0):
         s.settimeout(timeout)


### PR DESCRIPTION
- Don't print a warning that the response came from an unexpected
  source if our server is a multicast address. The multicast test
  here is ridiculous and only works for IPv4.
- OpenBSD requires setsockopt(IPPROTO_IP, IP_MULTICAST_IF, ip_addr)
  to be called before being able to send multicast packets. Since
  we don't always have a source address to bind to, work around it
  by only doing it when we have "srcip" in options. (-b<IP>)
